### PR TITLE
fix package.js and package_bg.wasm routes

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 
 <link href="https://fonts.googleapis.com/css?family=Karla" rel="stylesheet">
 
-<script src='pkg/package.js'></script>
+<script src='/pkg/package.js'></script>
 
 <script>
     // the `wasm_bindgen` global is set to the exports of the Rust module
@@ -30,7 +30,7 @@
     }
     // here we tell bindgen the path to the wasm file so it can run
     // initialization and return to us a promise when it's done
-    wasm_bindgen('pkg/package_bg.wasm')
+    wasm_bindgen('/pkg/package_bg.wasm')
         .then(run)
         .catch(console.error);
 </script>


### PR DESCRIPTION
The error is that packages are being served from relative paths, which means the request was being intercepted by `serve.py` and sending `index.html` instead, hence the strange "unexpected <" error.

Closes #1 